### PR TITLE
Lisää Suosituimmat tuotteet -osio hinnasto- ja yhteystietosivuille (Vibe Kanban)

### DIFF
--- a/hinnasto.html
+++ b/hinnasto.html
@@ -503,6 +503,45 @@
         </div>
         <!-- End of Groweo Smart Form -->
       </section>
+
+      <section class="products container">
+        <h2>Suosituimmat tuotteet</h2>
+        <div class="products-grid">
+          <div class="product-embed">
+            <iframe
+              src="https://holvi.com/shop/iltametsuri/product/87a696e481185a662c8ff7797b65c22f/embedded/"
+              frameborder="0"
+              title="Tuore koivuklapi 5m3 kotiintoimitettuna"
+              loading="lazy"
+            ></iframe>
+          </div>
+          <div class="product-embed">
+            <iframe
+              src="https://holvi.com/shop/iltametsuri/product/0bb47eec1e2f7be081246b0d7a3f7ccf/embedded/"
+              frameborder="0"
+              title="Kuiva koivuklapi 15 kpl 40l säkkiä (n. 1 im3)"
+              loading="lazy"
+            ></iframe>
+          </div>
+          <div class="product-embed">
+            <iframe
+              src="https://holvi.com/shop/iltametsuri/product/c0ec61c9f11035f2ed1d87ddd6a7c47c/embedded/"
+              frameborder="0"
+              title="Kuiva koivuklapi 1m3 säkki"
+              loading="lazy"
+            ></iframe>
+          </div>
+        </div>
+        <p class="products-cta">
+          <a
+            href="https://holvi.com/shop/iltametsuri/"
+            class="button external-link"
+            target="_blank"
+            rel="noopener nofollow"
+            >Katso kaikki tuotteet</a
+          >
+        </p>
+      </section>
     </main>
 
     <footer class="footer">

--- a/yhteystiedot.html
+++ b/yhteystiedot.html
@@ -448,6 +448,45 @@
         </div>
         <!-- End of Groweo Smart Form -->
       </section>
+
+      <section class="products container">
+        <h2>Suosituimmat tuotteet</h2>
+        <div class="products-grid">
+          <div class="product-embed">
+            <iframe
+              src="https://holvi.com/shop/iltametsuri/product/87a696e481185a662c8ff7797b65c22f/embedded/"
+              frameborder="0"
+              title="Tuore koivuklapi 5m3 kotiintoimitettuna"
+              loading="lazy"
+            ></iframe>
+          </div>
+          <div class="product-embed">
+            <iframe
+              src="https://holvi.com/shop/iltametsuri/product/0bb47eec1e2f7be081246b0d7a3f7ccf/embedded/"
+              frameborder="0"
+              title="Kuiva koivuklapi 15 kpl 40l säkkiä (n. 1 im3)"
+              loading="lazy"
+            ></iframe>
+          </div>
+          <div class="product-embed">
+            <iframe
+              src="https://holvi.com/shop/iltametsuri/product/c0ec61c9f11035f2ed1d87ddd6a7c47c/embedded/"
+              frameborder="0"
+              title="Kuiva koivuklapi 1m3 säkki"
+              loading="lazy"
+            ></iframe>
+          </div>
+        </div>
+        <p class="products-cta">
+          <a
+            href="https://holvi.com/shop/iltametsuri/"
+            class="button external-link"
+            target="_blank"
+            rel="noopener nofollow"
+            >Katso kaikki tuotteet</a
+          >
+        </p>
+      </section>
     </main>
 
     <footer class="footer">


### PR DESCRIPTION
## Yhteenveto

Tämä PR lisää "Suosituimmat tuotteet" -osion hinnasto.html- ja yhteystiedot.html-sivuille, jotta asiakkaat näkevät suosituimmat tuotteet useammalla sivulla.

## Muutokset

- Lisätty `<section class="products container">` -osio hinnasto.html-sivulle ennen footeria
- Lisätty sama osio yhteystiedot.html-sivulle ennen footeria
- Molemmat osiot sisältävät samat kolme tuotetta kuin etusivulla:
  1. Tuore koivuklapi 5m3 kotiintoimitettuna
  2. Kuiva koivuklapi 15 kpl 40l säkkiä (n. 1 im3)
  3. Kuiva koivuklapi 1m3 säkki
- Mukana linkki verkkokauppaan ("Katso kaikki tuotteet")

## Miksi

Suosituimpien tuotteiden näyttäminen useammalla sivulla parantaa tuotteiden löydettävyyttä ja voi lisätä myyntiä, kun asiakkaat näkevät tuotevaihtoehdot myös hinnasto- ja yhteystietosivuilla pelkän etusivun sijaan.

## Toteutus

Tuoteosio on kopioitu suoraan etusivulta (index.html) varmistaen yhtenäisen ulkoasun ja samat tuotteet. Holvi-verkkokaupan upotukset käyttävät samoja tuote-ID:itä ja title-attribuutteja kuin etusivulla.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)